### PR TITLE
Avoid TraitError when setting root_dir

### DIFF
--- a/pytest_jupyter/jupyter_server.py
+++ b/pytest_jupyter/jupyter_server.py
@@ -243,7 +243,7 @@ def jp_kernelspecs(jp_data_dir):
 @pytest.fixture(params=[True, False])
 def jp_contents_manager(request, jp_root_dir):
     """Returns a FileContentsManager instance based on the use_atomic_writing parameter value."""
-    return FileContentsManager(root_dir=jp_root_dir, use_atomic_writing=request.param)
+    return FileContentsManager(root_dir=str(jp_root_dir), use_atomic_writing=request.param)
 
 
 @pytest.fixture


### PR DESCRIPTION
The `fp_contents_manager` fixture needed to cast its initialization of `root_dir` using `str(fp_root_dir)` to avoid:
```
traitlets.traitlets.TraitError: The 'root_dir' trait of a FileContentsManager instance expected a unicode string, not the PosixPath PosixPath('/private/var/folders/4w/qxgsbhyx1y93qlk9mnzwjryc0000gn/T/pytest-of-kbates/pytest-101/test_saving_different_chunks_F0/root_dir'
```