### PR TITLE
Include LICENSE file in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include README.md
+include pyproject.toml


### PR DESCRIPTION
Publication of a conda package is blocked due to the missing LICENSE file.

This will correct it (but requires a new release).

> BTW: if some people are interested by being co-maintainer to the conda package recipe, I happily add them.