### PR TITLE
Refactor fixtures

### DIFF
--- a/pytest_jupyter/__init__.py
+++ b/pytest_jupyter/__init__.py
@@ -1,12 +1,4 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import asyncio
-import os
-
 from .jupyter_core import *  # noqa
-
-if os.name == "nt":
-    asyncio.set_event_loop_policy(
-        asyncio.WindowsSelectorEventLoopPolicy()  # type:ignore[attr-defined]
-    )

--- a/pytest_jupyter/jupyter_core.py
+++ b/pytest_jupyter/jupyter_core.py
@@ -47,6 +47,22 @@ def jp_asyncio_loop():
     loop.close()
 
 
+@pytest.fixture(autouse=True)
+def io_loop(jp_asyncio_loop):
+    """Override the io_loop for pytest_tornasync.  This is a no-op
+    if tornado is not installed."""
+
+    async def get_tornado_loop():
+        try:
+            from tornado.ioloop import IOLoop
+
+            return IOLoop.current()
+        except ImportError:
+            pass
+
+    return jp_asyncio_loop.run_until_complete(get_tornado_loop())
+
+
 @pytest.fixture
 def jp_home_dir(tmp_path):
     """Provides a temporary HOME directory value."""

--- a/pytest_jupyter/jupyter_server.py
+++ b/pytest_jupyter/jupyter_server.py
@@ -52,12 +52,9 @@ from pytest_jupyter.utils import mkdir
 pytest_plugins = ["pytest_tornasync"]
 
 
-@pytest.fixture(autouse=True)
-def io_loop(jp_asyncio_loop):
-    async def get_tornado_loop():
-        return tornado.ioloop.IOLoop.current()
-
-    return jp_asyncio_loop.run_until_complete(get_tornado_loop())
+# Override some of the fixtures from pytest_tornasync
+# The io_loop fixture is overidden in jupyter_core.py so it
+# can be shared by other plugins that need it (e.g. jupyter_client.py).
 
 
 @pytest.fixture
@@ -93,6 +90,9 @@ def http_server(io_loop, http_server_port, jp_web_app):
     http_server_port[0].close()
 
 
+# End pytest_tornasync overrides
+
+
 @pytest.fixture
 def jp_server_config():
     """Allows tests to setup their specific configuration values."""
@@ -125,17 +125,17 @@ def jp_argv():
     return []
 
 
-@pytest.fixture
-def jp_extension_environ(jp_env_config_path, monkeypatch):
-    """Monkeypatch a Jupyter Extension's config path into each test's environment variable"""
-    monkeypatch.setattr(serverextension, "ENV_CONFIG_PATH", [str(jp_env_config_path)])
-
-
-@pytest.fixture
+@pytest.fixture()
 def jp_http_port(http_server_port):
     """Returns the port value from the http_server_port fixture."""
     yield http_server_port[-1]
     http_server_port[0].close()
+
+
+@pytest.fixture
+def jp_extension_environ(jp_env_config_path, monkeypatch):
+    """Monkeypatch a Jupyter Extension's config path into each test's environment variable"""
+    monkeypatch.setattr(serverextension, "ENV_CONFIG_PATH", [str(jp_env_config_path)])
 
 
 @pytest.fixture

--- a/pytest_jupyter/jupyter_server.py
+++ b/pytest_jupyter/jupyter_server.py
@@ -1,7 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import asyncio
 import importlib
 import io
 import logging
@@ -45,26 +44,20 @@ except ImportError:
     )
 
 
+# Bring in core plugins.
+from pytest_jupyter import *  # noqa
 from pytest_jupyter.utils import mkdir
 
 # List of dependencies needed for this plugin.
-pytest_plugins = ["pytest_tornasync", "pytest_jupyter.jupyter_client"]
-
-
-@pytest.fixture
-def asyncio_loop():
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    yield loop
-    loop.close()
+pytest_plugins = ["pytest_tornasync"]
 
 
 @pytest.fixture(autouse=True)
-def io_loop(asyncio_loop):
+def io_loop(jp_asyncio_loop):
     async def get_tornado_loop():
         return tornado.ioloop.IOLoop.current()
 
-    return asyncio_loop.run_until_complete(get_tornado_loop())
+    return jp_asyncio_loop.run_until_complete(get_tornado_loop())
 
 
 @pytest.fixture
@@ -192,9 +185,8 @@ def jp_configurable_serverapp(
     tmp_path,
     jp_root_dir,
     jp_logging_stream,
-    asyncio_loop,
+    jp_asyncio_loop,
     io_loop,
-    echo_kernel_spec,  # noqa
 ):
     """Starts a Jupyter Server instance based on
     the provided configuration values.
@@ -261,14 +253,14 @@ def jp_configurable_serverapp(
         app.log.propagate = True
         app.log.handlers = []
         # Initialize app without httpserver
-        if asyncio_loop.is_running():
+        if jp_asyncio_loop.is_running():
             app.initialize(argv=argv, new_httpserver=False)
         else:
 
             async def initialize_app():
                 app.initialize(argv=argv, new_httpserver=False)
 
-            asyncio_loop.run_until_complete(initialize_app())
+            jp_asyncio_loop.run_until_complete(initialize_app())
         # Reroute all logging StreamHandlers away from stdin/stdout since pytest hijacks
         # these streams and closes them at unfortunate times.
         stream_handlers = [h for h in app.log.handlers if isinstance(h, logging.StreamHandler)]
@@ -410,11 +402,11 @@ def jp_create_notebook(jp_root_dir):
 
 
 @pytest.fixture(autouse=True)
-def jp_server_cleanup(asyncio_loop):
+def jp_server_cleanup(jp_asyncio_loop):
     yield
     app: ServerApp = ServerApp.instance()
     try:
-        asyncio_loop.run_until_complete(app._cleanup())
+        jp_asyncio_loop.run_until_complete(app._cleanup())
     except (RuntimeError, SystemExit) as e:
         print("ignoring cleanup error", e)
     if hasattr(app, "kernel_manager"):

--- a/tests/test_jupyter_client.py
+++ b/tests/test_jupyter_client.py
@@ -5,17 +5,17 @@ from jupyter_client.session import Session
 from pytest_jupyter.echo_kernel import EchoKernel
 
 
-def test_zmq_context(zmq_context):
-    assert isinstance(zmq_context.underlying, int)
+def test_zmq_context(jp_zmq_context):
+    assert isinstance(jp_zmq_context.underlying, int)
 
 
-async def test_start_kernel(start_kernel):
-    km, kc = await start_kernel()
+async def test_start_kernel(jp_start_kernel):
+    km, kc = await jp_start_kernel()
     assert km.kernel_name == "echo"
     msg = await kc.execute("hello", reply=True)
     assert msg["content"]["status"] == "ok"
 
-    km, kc = await start_kernel("python3")
+    km, kc = await jp_start_kernel("python3")
     assert km.kernel_name == "python3"
     msg = await kc.execute("print('hi')", reply=True)
     assert msg["content"]["status"] == "ok"


### PR DESCRIPTION
Move more logic and fixtures including `io_loop` into core so they can be shared.
Prefix fixture names where appropriate.
Automatically install echo kernel in base environment.