### PR TITLE
hoist __version__

### DIFF
--- a/pytest_jupyter/__init__.py
+++ b/pytest_jupyter/__init__.py
@@ -1,5 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+__all__ = ["__version__"]
+
 from ._version import __version__
 from .jupyter_core import *  # noqa

--- a/pytest_jupyter/__init__.py
+++ b/pytest_jupyter/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from ._version import __version__
 from .jupyter_core import *  # noqa


### PR DESCRIPTION
Yep. Just exports `__version__`.

It would be really nice to get some `py.typed` into this, as the scope isn't too large.