### PR TITLE
Use native kernel by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,6 +131,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jupyter_server
+          package_download_extra_args: --pre
 
   jupyter_client_downstream:
     runs-on: ubuntu-latest
@@ -141,6 +142,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jupyter_client
+          package_download_extra_args: --pre
 
   tests_check: # This job does nothing and is only used for the branch protection
     if: always()

--- a/pytest_jupyter/jupyter_client.py
+++ b/pytest_jupyter/jupyter_client.py
@@ -5,6 +5,7 @@ import pytest
 
 try:
     import ipykernel  # noqa
+    from jupyter_client.kernelspec import NATIVE_KERNEL_NAME
     from jupyter_client.manager import start_new_async_kernel
 except ImportError:
     import warnings
@@ -35,7 +36,7 @@ def jp_start_kernel(jp_environ, jp_asyncio_loop):
     kms = []
     kcs = []
 
-    async def inner(kernel_name="echo", **kwargs):
+    async def inner(kernel_name=NATIVE_KERNEL_NAME, **kwargs):
         km, kc = await start_new_async_kernel(kernel_name=kernel_name, **kwargs)
         kms.append(km)
         kcs.append(kc)

--- a/pytest_jupyter/jupyter_server.py
+++ b/pytest_jupyter/jupyter_server.py
@@ -204,9 +204,6 @@ def jp_configurable_serverapp(
         c = Config(config)
         c.NotebookNotary.db_file = ":memory:"
 
-        if "default_kernel_name" not in c.MultiKernelManager:
-            c.MultiKernelManager.default_kernel_name = "echo"
-
         default_token = hexlify(os.urandom(4)).decode("ascii")
         if not is_v2:
             kwargs["token"] = default_token

--- a/tests/test_jupyter_client.py
+++ b/tests/test_jupyter_client.py
@@ -10,12 +10,12 @@ def test_zmq_context(jp_zmq_context):
 
 
 async def test_start_kernel(jp_start_kernel):
-    km, kc = await jp_start_kernel()
+    km, kc = await jp_start_kernel("echo")
     assert km.kernel_name == "echo"
     msg = await kc.execute("hello", reply=True)
     assert msg["content"]["status"] == "ok"
 
-    km, kc = await jp_start_kernel("python3")
+    km, kc = await jp_start_kernel()
     assert km.kernel_name == "python3"
     msg = await kc.execute("print('hi')", reply=True)
     assert msg["content"]["status"] == "ok"


### PR DESCRIPTION
I ran a comparison of starting a kernel 10 times, executing, and shutting down.  Here were the total times:

- echo 24s
- python3 8s
- xpython 8s
- xpython-raw 8s

So much for "echo" being faster.   😅 