### PR TITLE
Update release instructions with additonal commit steps

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,7 +25,8 @@ git clean -dffx
 echo "Enter new version"
 read new_version
 hatch version ${new_version}
-git tag -a ${new_version} -m "Release ${new_version}"
+git commit -a -m "Release ${new_version}"
+git tag -a v${new_version} -m "Release ${new_version}"
 ```
 
 ### Build the artifacts
@@ -41,7 +42,8 @@ python -m build .
 echo "Enter dev version"
 read dev_version
 hatch version ${dev_version}
-git push origin $(git branch --show-current)
+git commit -a -m "Prepare for next release"
+git push origin $(git branch --show-current) v${new_version}
 ```
 
 ### Publish the artifacts to pypi


### PR DESCRIPTION
In building the 0.7.0 release, there seemed to be some missing steps, primarily around the commit(s) of the (twice) updated `_version.py` file.  It also includes the `v` prefix on the tag name (to be consistent with existing tags) - along with its push.

Another area I wasn't sure about was the authoring of the [Release itself](https://github.com/jupyter-server/pytest-jupyter/releases).  I used the `Generate release notes` button to build the content, then added the contributors and full change log entries.

Also, I wasn't sure where the assets (`assets_shas.json` and `metadata.json`) come from, so not sure if their generation should be addressed in the instructions as well.  **Note that the 0.7.0 does NOT current include those assets.**