### PR TITLE
Allow passing request_timeout to client_fetch

### DIFF
--- a/pytest_jupyter/jupyter_server.py
+++ b/pytest_jupyter/jupyter_server.py
@@ -315,8 +315,10 @@ def jp_fetch(jp_serverapp, http_server_client, jp_auth_header, jp_base_url):
         # Add auth keys to header, if not overridden
         for key, value in jp_auth_header.items():
             headers.setdefault(key, value)
+        # Handle timeout
+        request_timeout = kwargs.pop("request_timeout", 20)
         # Make request.
-        return http_server_client.fetch(url, headers=headers, request_timeout=20, **kwargs)
+        return http_server_client.fetch(url, headers=headers, request_timeout=request_timeout, **kwargs)
 
     return client_fetch
 

--- a/pytest_jupyter/jupyter_server.py
+++ b/pytest_jupyter/jupyter_server.py
@@ -318,7 +318,9 @@ def jp_fetch(jp_serverapp, http_server_client, jp_auth_header, jp_base_url):
         # Handle timeout
         request_timeout = kwargs.pop("request_timeout", 20)
         # Make request.
-        return http_server_client.fetch(url, headers=headers, request_timeout=request_timeout, **kwargs)
+        return http_server_client.fetch(
+            url, headers=headers, request_timeout=request_timeout, **kwargs
+        )
 
     return client_fetch
 


### PR DESCRIPTION
When using the `jp_fetch` function on `pytest` tests, the request timeout is hardcoded to 20 seconds. This change allows the users to pass a timeout as a method argument, still defaulting to 20 if it's not given.

I have some tests for endpoints that sometimes can take more than 20s and this change will make them pass.