### PR TITLE
Restore the ability to override a serverapp's HTTP port

### DIFF
--- a/pytest_jupyter/jupyter_server.py
+++ b/pytest_jupyter/jupyter_server.py
@@ -197,7 +197,7 @@ def jp_configurable_serverapp(
         app = ServerApp.instance(
             # Set the log level to debug for testing purposes
             log_level="DEBUG",
-            port=jp_http_port,
+            port=http_port,
             port_retries=0,
             open_browser=False,
             base_url=base_url,


### PR DESCRIPTION
When invoking the `jp_configurable_serverapp` fixture, there are multiple keyword arguments supported for overriding the values specified by other fixtures.

One of those keyword arguments, `http_port`, is never used. I believe this was accidentally broken by https://github.com/jupyter-server/pytest-jupyter/pull/33 where multiple variables named `http_port` referencing a provided fixture were renamed to `jp_http_port`.

However, that change also modified one instance of `http_port` that was not a reference to the fixture, but rather a reference to the keyword argument with that same name.

This change fixes that by undoing that one line of the change.