### PR TITLE
Improved doc string for jp_fetch to include how to provide query parameters in GET and json data in POST

### DIFF
--- a/pytest_jupyter/jupyter_server.py
+++ b/pytest_jupyter/jupyter_server.py
@@ -274,7 +274,7 @@ def jp_fetch(jp_serverapp, http_server_client, jp_auth_header, jp_base_url):
     .. code-block:: python
 
         async def my_test(jp_fetch):
-            response = await jp_fetch("api", "spec.yaml", params={'parameter': 'value'})
+            response = await jp_fetch("api", "spec.yaml", params={"parameter": "value"})
             ...
 
     A POST request with data:
@@ -282,7 +282,9 @@ def jp_fetch(jp_serverapp, http_server_client, jp_auth_header, jp_base_url):
     .. code-block:: python
 
         async def my_test(jp_fetch):
-            response = await jp_fetch("api", "spec.yaml", body=json.dumps({'parameter': 'value'}), method='POST')
+            response = await jp_fetch(
+                "api", "spec.yaml", body=json.dumps({"parameter": "value"}), method="POST"
+            )
             ...
 
     """

--- a/pytest_jupyter/jupyter_server.py
+++ b/pytest_jupyter/jupyter_server.py
@@ -268,6 +268,23 @@ def jp_fetch(jp_serverapp, http_server_client, jp_auth_header, jp_base_url):
         async def my_test(jp_fetch):
             response = await jp_fetch("api", "spec.yaml")
             ...
+
+    With query parameters:
+
+    .. code-block:: python
+
+        async def my_test(jp_fetch):
+            response = await jp_fetch("api", "spec.yaml", params={'parameter': 'value'})
+            ...
+
+    A POST request with data:
+
+    .. code-block:: python
+
+        async def my_test(jp_fetch):
+            response = await jp_fetch("api", "spec.yaml", body=json.dumps({'parameter': 'value'}), method='POST')
+            ...
+
     """
 
     def client_fetch(*parts, headers=None, params=None, **kwargs):

--- a/pytest_jupyter/jupyter_server.py
+++ b/pytest_jupyter/jupyter_server.py
@@ -282,7 +282,9 @@ def jp_fetch(jp_serverapp, http_server_client, jp_auth_header, jp_base_url):
     .. code-block:: python
 
         async def my_test(jp_fetch):
-            response = await jp_fetch("api", "spec.yaml", method='POST', body=json.dumps({'parameter': 'value'}))
+            response = await jp_fetch(
+                "api", "spec.yaml", method="POST", body=json.dumps({"parameter": "value"})
+            )
             ...
 
     """

--- a/pytest_jupyter/jupyter_server.py
+++ b/pytest_jupyter/jupyter_server.py
@@ -282,7 +282,7 @@ def jp_fetch(jp_serverapp, http_server_client, jp_auth_header, jp_base_url):
     .. code-block:: python
 
         async def my_test(jp_fetch):
-            response = await jp_fetch("api", "spec.yaml", body=json.dumps({'parameter': 'value'}), method='POST')
+            response = await jp_fetch("api", "spec.yaml", method='POST', body=json.dumps({'parameter': 'value'}))
             ...
 
     """


### PR DESCRIPTION
It took me a rather long time to work out this was how to do this. 

Think this change to the docs might help other users.