### PR TITLE
Drop 3.8, Start testing on 3.13, 3.14 and 3.14t, update precommit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.13", "3.14", "3.14t"]
         include:
           - os: windows-latest
             python-version: "3.9"
           - os: ubuntu-latest
             python-version: "pypy-3.9"
-          - os: ubuntu-latest
-            python-version: "3.8"
           - os: macos-latest
             python-version: "3.10"
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Run the tests on pypy
         if: ${{ startsWith(matrix.python-version, 'pypy') }}
         run: |
-          hatch run test:nowarn || hatch run test:nowarn --lf
+          hatch run test:nowarn
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
-        run: hatch run cov:test || hatch run test:test --lf
+        run: hatch run cov:test
       - uses: jupyterlab/maintainer-tools/.github/actions/upload-coverage@v1
 
   coverage:
@@ -80,7 +80,7 @@ jobs:
           dependency_type: minimum
       - name: Run the unit tests
         run: |
-          hatch -v run test:nowarn || hatch run test:nowarn --lf
+          hatch -v run test:nowarn
 
   test_prereleases:
     name: Test Prereleases
@@ -93,7 +93,7 @@ jobs:
           dependency_type: pre
       - name: Run the tests
         run: |
-          hatch run test:nowarn || hatch run test:nowarn --lf
+          hatch run test:nowarn
 
   make_sdist:
     name: Make SDist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: check-case-conflict
       - id: check-ast
@@ -21,12 +21,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.27.4
+    rev: 0.34.1
     hooks:
       - id: check-github-workflows
 
-  - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.17
+  - repo: https://github.com/hukkin/mdformat
+    rev: 0.7.22
     hooks:
       - id: mdformat
 
@@ -37,19 +37,19 @@ repos:
         types_or: [yaml, html, json]
 
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: "1.16.0"
+    rev: "1.20.0"
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==23.7.0]
 
   - repo: https://github.com/codespell-project/codespell
-    rev: "v2.2.6"
+    rev: "v2.4.1"
     hooks:
       - id: codespell
         args: ["-L", "sur,nd"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.8.0"
+    rev: "v1.18.2"
     hooks:
       - id: mypy
         files: pytest_jupyter
@@ -71,16 +71,16 @@ repos:
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.14.0
     hooks:
-      - id: ruff
+      - id: ruff-check
         types_or: [python, jupyter]
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
         types_or: [python, jupyter]
 
   - repo: https://github.com/scientific-python/cookie
-    rev: "2024.01.24"
+    rev: "2025.10.01"
     hooks:
       - id: sp-repo-review
         additional_dependencies: ["repo-review[cli]"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,13 +109,13 @@
 
 - Add more ci checks by @blink1073 in https://github.com/jupyter-server/pytest-jupyter/pull/42
 - Bump ruff from 0.0.189 to 0.0.194 by @dependabot in https://github.com/jupyter-server/pytest-jupyter/pull/43
-- Bump black\[jupyter\] from 22.10.0 to 22.12.0 by @dependabot in https://github.com/jupyter-server/pytest-jupyter/pull/44
+- Bump black[jupyter] from 22.10.0 to 22.12.0 by @dependabot in https://github.com/jupyter-server/pytest-jupyter/pull/44
 - Clean up lint by @blink1073 in https://github.com/jupyter-server/pytest-jupyter/pull/45
-- \[pre-commit.ci\] pre-commit autoupdate by @pre-commit-ci in https://github.com/jupyter-server/pytest-jupyter/pull/46
+- [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci in https://github.com/jupyter-server/pytest-jupyter/pull/46
 - Sync lint deps by @blink1073 in https://github.com/jupyter-server/pytest-jupyter/pull/47
 - Add more linting by @blink1073 in https://github.com/jupyter-server/pytest-jupyter/pull/48
-- \[pre-commit.ci\] pre-commit autoupdate by @pre-commit-ci in https://github.com/jupyter-server/pytest-jupyter/pull/49
-- \[pre-commit.ci\] pre-commit autoupdate by @pre-commit-ci in https://github.com/jupyter-server/pytest-jupyter/pull/50
+- [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci in https://github.com/jupyter-server/pytest-jupyter/pull/49
+- [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci in https://github.com/jupyter-server/pytest-jupyter/pull/50
 - Enable header overrides in jp_ws_fetch fixture by @kevin-bates in https://github.com/jupyter-server/pytest-jupyter/pull/51
 
 ([GitHub contributors page for this release](https://github.com/jupyter-server/pytest-jupyter/graphs/contributors?from=2022-12-19&to=2023-03-30&type=c))

--- a/README.md
+++ b/README.md
@@ -40,16 +40,16 @@ that provides a factory function that starts a kernel using the `echo` kernel
 by default.
 
 *Note*: The server plugin also includes the client plugin, so you can use both
-sets of fixtures with `"pytest_jupyter.jupyter_server"`.  Both the `client`
+sets of fixtures with `"pytest_jupyter.jupyter_server"`. Both the `client`
 and `server` plugins also include the core fixtures.
 
 *Note*: The client and server plugins use `pytest-tornasync` for async
-test suite running.  It may not compatible with `pytest-asyncio`, meaning
-that all fixtures must be synchronous.  You can use the `asyncio_loop` fixture
+test suite running. It may not compatible with `pytest-asyncio`, meaning
+that all fixtures must be synchronous. You can use the `asyncio_loop` fixture
 and run `asyncio_loop.run_until_complete` against an async function in your
 fixtures if needed.
 
-The server fixures use the echo kernel by default.  To override this behavior,
+The server fixures use the echo kernel by default. To override this behavior,
 override the `jp_server_config` fixture and add the following config:
 
 ```json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pytest>=7.0",
     "jupyter_core>=5.7"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 
 [project.optional-dependencies]
@@ -100,7 +100,7 @@ dependencies = ["pre-commit"]
 detached = true
 [tool.hatch.envs.lint.scripts]
 build = [
-    "pre-commit run --all-files ruff",
+    "pre-commit run --all-files ruff-check",
     "pre-commit run --all-files ruff-format"
 ]
 
@@ -125,6 +125,7 @@ filterwarnings= [
   # Fail on warnings
   "error",
   "module:datetime.datetime.utc:DeprecationWarning",
+  "ignore:.*asyncio.DefaultEventLoopPolicy.*:DeprecationWarning"
 ]
 
 [tool.coverage.report]
@@ -147,7 +148,7 @@ source = ["pytest_jupyter"]
 
 [tool.mypy]
 files = "pytest_jupyter"
-python_version = "3.8"
+python_version = "3.10"
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 disable_error_code = ["no-untyped-def"]

--- a/pytest_jupyter/echo_kernel.py
+++ b/pytest_jupyter/echo_kernel.py
@@ -1,4 +1,5 @@
 """A simple echo kernel."""
+
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 from __future__ import annotations
@@ -61,7 +62,7 @@ class EchoKernel(Kernel):
 class EchoKernelApp(IPKernelApp):
     """An app for the echo kernel."""
 
-    kernel_class = EchoKernel  # type:ignore[assignment]
+    kernel_class = EchoKernel
 
 
 if __name__ == "__main__":

--- a/pytest_jupyter/jupyter_client.py
+++ b/pytest_jupyter/jupyter_client.py
@@ -23,17 +23,17 @@ except ImportError:
 from pytest_jupyter.jupyter_core import *  # noqa: F403
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_zmq_context():
     """Get a zmq context."""
-    import zmq
+    import zmq  # noqa: PLC0415
 
     ctx = zmq.asyncio.Context()
     yield ctx
     ctx.term()
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_start_kernel(jp_environ, jp_asyncio_loop):
     """Get a function to a kernel and clean up resources when done."""
     kms = []

--- a/pytest_jupyter/jupyter_core.py
+++ b/pytest_jupyter/jupyter_core.py
@@ -1,9 +1,11 @@
 """Fixtures for use with jupyter core and downstream."""
+
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import json
 import os
 import sys
+import warnings
 from inspect import iscoroutinefunction
 from pathlib import Path
 
@@ -38,7 +40,13 @@ if resource is not None:
 @pytest.fixture(autouse=True)
 def jp_asyncio_loop():
     """Get an asyncio loop."""
-    loop = ensure_event_loop(prefer_selector_loop=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=".*WindowsSelectorEventLoopPolicy.*",
+            category=DeprecationWarning,
+        )
+        loop = ensure_event_loop(prefer_selector_loop=True)
     yield loop
     loop.close()
 
@@ -61,79 +69,91 @@ def pytest_pyfunc_call(pyfuncitem):
         pyfuncitem.obj(**testargs)
         return True
 
-    loop = ensure_event_loop(prefer_selector_loop=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=".*WindowsSelectorEventLoopPolicy.*",
+            category=DeprecationWarning,
+        )
+        loop = ensure_event_loop(prefer_selector_loop=True)
     loop.run_until_complete(pyfuncitem.obj(**testargs))
     return True
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_home_dir(tmp_path):
     """Provides a temporary HOME directory value."""
     return mkdir(tmp_path, "home")
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_data_dir(tmp_path):
     """Provides a temporary Jupyter data dir directory value."""
     return mkdir(tmp_path, "data")
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_config_dir(tmp_path):
     """Provides a temporary Jupyter config dir directory value."""
     return mkdir(tmp_path, "config")
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_runtime_dir(tmp_path):
     """Provides a temporary Jupyter runtime dir directory value."""
     return mkdir(tmp_path, "runtime")
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_system_jupyter_path(tmp_path):
     """Provides a temporary Jupyter system path value."""
     return mkdir(tmp_path, "share", "jupyter")
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_env_jupyter_path(tmp_path):
     """Provides a temporary Jupyter env system path value."""
     return mkdir(tmp_path, "env", "share", "jupyter")
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_system_config_path(tmp_path):
     """Provides a temporary Jupyter config path value."""
     return mkdir(tmp_path, "etc", "jupyter")
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_env_config_path(tmp_path):
     """Provides a temporary Jupyter env config path value."""
     return mkdir(tmp_path, "env", "etc", "jupyter")
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_kernel_dir(jp_data_dir):
     """Get the directory for kernel specs."""
     return mkdir(jp_data_dir, "kernels")
 
 
-@pytest.fixture()
+@pytest.fixture
 def echo_kernel_spec(jp_kernel_dir):
     """Install a kernel spec for the echo kernel."""
     test_dir = Path(jp_kernel_dir) / "echo"
     test_dir.mkdir(parents=True, exist_ok=True)
-    argv = [sys.executable, "-m", "pytest_jupyter.echo_kernel", "-f", "{connection_file}"]
+    argv = [
+        sys.executable,
+        "-m",
+        "pytest_jupyter.echo_kernel",
+        "-f",
+        "{connection_file}",
+    ]
     kernel_data = {"argv": argv, "display_name": "echo", "language": "echo"}
     spec_file_path = Path(test_dir / "kernel.json")
     spec_file_path.write_text(json.dumps(kernel_data), "utf8")
     return str(test_dir)
 
 
-@pytest.fixture()
-def jp_environ(  # noqa: PT004
+@pytest.fixture
+def jp_environ(
     monkeypatch,
     tmp_path,
     jp_home_dir,

--- a/pytest_jupyter/jupyter_server.py
+++ b/pytest_jupyter/jupyter_server.py
@@ -1,4 +1,5 @@
 """Fixtures for use with jupyter server and downstream."""
+
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 from __future__ import annotations
@@ -54,7 +55,7 @@ from pytest_jupyter.pytest_tornasync import *  # noqa: F403
 from pytest_jupyter.utils import mkdir
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_server_config():
     """Allows tests to setup their specific configuration values."""
     if is_v2:
@@ -68,39 +69,39 @@ def jp_server_config():
     return Config(config)
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_root_dir(tmp_path):
     """Provides a temporary Jupyter root directory value."""
     return mkdir(tmp_path, "root_dir")
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_template_dir(tmp_path):
     """Provides a temporary Jupyter templates directory value."""
     return mkdir(tmp_path, "templates")
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_argv():
     """Allows tests to setup specific argv values."""
     return []
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_http_port(http_server_port):
     """Returns the port value from the http_server_port fixture."""
     yield http_server_port[-1]
     http_server_port[0].close()
 
 
-@pytest.fixture()
-def jp_extension_environ(jp_env_config_path, monkeypatch):  # noqa: PT004
+@pytest.fixture
+def jp_extension_environ(jp_env_config_path, monkeypatch):
     """Monkeypatch a Jupyter Extension's config path into each test's environment variable"""
     monkeypatch.setattr(serverextension, "ENV_CONFIG_PATH", [str(jp_env_config_path)])
 
 
-@pytest.fixture()
-def jp_nbconvert_templates(jp_data_dir):  # noqa: PT004
+@pytest.fixture
+def jp_nbconvert_templates(jp_data_dir):
     """Setups up a temporary directory consisting of the nbconvert templates."""
 
     # Get path to nbconvert template directory *before*
@@ -119,7 +120,7 @@ def jp_nbconvert_templates(jp_data_dir):  # noqa: PT004
         shutil.copytree(nbconvert_path, str(nbconvert_target))
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_logging_stream():
     """StringIO stream intended to be used by the core
     Jupyter ServerApp logger's default StreamHandler. This
@@ -135,7 +136,7 @@ def jp_logging_stream():
     return output
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_configurable_serverapp(
     jp_nbconvert_templates,  # this fixture must precede jp_environ
     jp_environ,
@@ -230,19 +231,41 @@ def jp_configurable_serverapp(
     return _configurable_serverapp
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_serverapp(jp_server_config, jp_argv, jp_configurable_serverapp):
     """Starts a Jupyter Server instance based on the established configuration values."""
-    return jp_configurable_serverapp(config=jp_server_config, argv=jp_argv)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=".*WindowsProactorEventLoopPolicy.*",
+            category=DeprecationWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message=".*WindowsSelectorEventLoopPolicy.*",
+            category=DeprecationWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message=".*get_event_loop_policy.*",
+            category=DeprecationWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message=".*set_event_loop_policy.*",
+            category=DeprecationWarning,
+        )
+
+        return jp_configurable_serverapp(config=jp_server_config, argv=jp_argv)
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_web_app(jp_serverapp):
     """app fixture is needed by pytest_tornasync plugin"""
     return jp_serverapp.web_app
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_auth_header(jp_serverapp):
     """Configures an authorization header using the token from the serverapp fixture."""
     if not is_v2:
@@ -250,13 +273,13 @@ def jp_auth_header(jp_serverapp):
     return {"Authorization": f"token {jp_serverapp.identity_provider.token}"}
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_base_url():
     """Returns the base url to use for the test."""
     return "/a%40b/"
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_fetch(jp_serverapp, http_server_client, jp_auth_header, jp_base_url):
     """Sends an (asynchronous) HTTP request to a test server.
     The fixture is a factory; it can be called like
@@ -312,7 +335,7 @@ def jp_fetch(jp_serverapp, http_server_client, jp_auth_header, jp_base_url):
     return client_fetch
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_ws_fetch(jp_serverapp, http_server_client, jp_auth_header, jp_http_port, jp_base_url):
     """Sends a websocket request to a test server.
     The fixture is a factory; it can be called like
@@ -357,7 +380,7 @@ def jp_ws_fetch(jp_serverapp, http_server_client, jp_auth_header, jp_http_port, 
     return client_fetch
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_create_notebook(jp_root_dir):
     """Creates a notebook in the test's home directory."""
 
@@ -380,7 +403,7 @@ def jp_create_notebook(jp_root_dir):
 
 
 @pytest.fixture(autouse=True)
-def jp_server_cleanup(jp_asyncio_loop):  # noqa: PT004
+def jp_server_cleanup(jp_asyncio_loop):
     """Automatically cleans up server resources."""
     yield
     app: ServerApp = ServerApp.instance()
@@ -393,7 +416,7 @@ def jp_server_cleanup(jp_asyncio_loop):  # noqa: PT004
     ServerApp.clear_instance()
 
 
-@pytest.fixture()
+@pytest.fixture
 def send_request(jp_fetch, jp_ws_fetch):
     """Send to Jupyter Server and return response code."""
 
@@ -415,7 +438,7 @@ def send_request(jp_fetch, jp_ws_fetch):
     return _
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_server_auth_core_resources():
     """The core auth resources for use with a server."""
     modules = []
@@ -432,7 +455,7 @@ def jp_server_auth_core_resources():
     return resource_map
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_server_auth_resources(jp_server_auth_core_resources):
     """The auth resources used by the server."""
     return jp_server_auth_core_resources
@@ -512,7 +535,7 @@ class _Authorizer(Authorizer):
         )
 
 
-@pytest.fixture()
+@pytest.fixture
 def jp_server_authorizer(jp_server_auth_resources):
     """An authorizer for the server."""
     auth_klass = _Authorizer

--- a/pytest_jupyter/pytest_tornasync.py
+++ b/pytest_jupyter/pytest_tornasync.py
@@ -1,6 +1,7 @@
 """Vendored fork of pytest_tornasync from
-  https://github.com/eukaryote/pytest-tornasync/blob/9f1bdeec3eb5816e0183f975ca65b5f6f29fbfbb/src/pytest_tornasync/plugin.py
+https://github.com/eukaryote/pytest-tornasync/blob/9f1bdeec3eb5816e0183f975ca65b5f6f29fbfbb/src/pytest_tornasync/plugin.py
 """
+
 import asyncio
 from contextlib import closing
 
@@ -18,13 +19,13 @@ import pytest
 from pytest_jupyter.jupyter_core import *  # noqa: F403
 
 
-@pytest.fixture()
+@pytest.fixture
 def io_loop(jp_asyncio_loop):
     """Get the current tornado event loop."""
     return tornado.ioloop.IOLoop.current()
 
 
-@pytest.fixture()
+@pytest.fixture
 def http_server(jp_asyncio_loop, http_server_port, jp_web_app):
     """Start a tornado HTTP server that listens on all available interfaces."""
 
@@ -47,7 +48,7 @@ def http_server(jp_asyncio_loop, http_server_port, jp_web_app):
     http_server_port[0].close()
 
 
-@pytest.fixture()
+@pytest.fixture
 def http_server_port():
     """
     Port used by `http_server`.
@@ -55,7 +56,7 @@ def http_server_port():
     return tornado.testing.bind_unused_port()
 
 
-@pytest.fixture()
+@pytest.fixture
 def http_server_client(http_server, jp_asyncio_loop):
     """
     Create an asynchronous HTTP client that can fetch from `http_server`.
@@ -73,12 +74,12 @@ def http_server_client(http_server, jp_asyncio_loop):
 class AsyncHTTPServerClient(SimpleAsyncHTTPClient):
     """An async http server client."""
 
-    def initialize(self, *, http_server=None):
+    def initialize(self, *, http_server=None):  # type: ignore[override]
         """Initialize the client."""
         super().initialize()
         self._http_server = http_server
 
-    def fetch(self, path, **kwargs):
+    def fetch(self, path, **kwargs):  # type: ignore[override]
         """
         Fetch `path` from test server, passing `kwargs` to the `fetch`
         of the underlying `SimpleAsyncHTTPClient`.

--- a/pytest_jupyter/utils.py
+++ b/pytest_jupyter/utils.py
@@ -1,4 +1,5 @@
 """Utilities for pytest-jupyter."""
+
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 from pathlib import Path


### PR DESCRIPTION
This also ignore some new warnings about eventloops on Python 3.14 and
above (for now), they will need to be fixed before 3.16.